### PR TITLE
feat: add virustotal command and VirusTotalClient scaffold

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -49,6 +49,13 @@ whobe
    :prog: whobe
    :nested: full
 
+virustotal
+^^^^^^^^^^
+
+.. click:: valkyrie_tools.virustotal:cli
+   :prog: virustotal
+   :nested: full
+
 
 API Reference
 -------------
@@ -201,6 +208,15 @@ valkyrie_tools.whois
 ^^^^^^^^^^^^^^^^^^^^
 
 .. automodule:: valkyrie_tools.whois
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+valkyrie_tools.virustotal
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. automodule:: valkyrie_tools.virustotal
    :members:
    :undoc-members:
    :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "valkyrie-tools"
-version = "1.3.2"
+version = "1.4.0"
 description = "Valkyrie Tools"
 authors = ["xransum <xransum@users.noreply.github.com>"]
 license = "MIT"
@@ -82,7 +82,7 @@ urlcheck = "valkyrie_tools.urlcheck:cli"
 ipcheck = "valkyrie_tools.ipcheck:cli"
 dnscheck = "valkyrie_tools.dnscheck:cli"
 whobe = "valkyrie_tools.whobe:cli"
-# vt = "valkyrie_tools.virustotal:cli"
+virustotal = "valkyrie_tools.virustotal:cli"
 
 [tool.coverage.paths]
 source = ["src", "*/site-packages"]

--- a/src/valkyrie_tools/valkyrie.py
+++ b/src/valkyrie_tools/valkyrie.py
@@ -2,7 +2,8 @@
 
 Entry point for the ``valkyrie`` command group, which exposes a ``config``
 sub-group with ``set``, ``get``, ``delete``, and ``list`` sub-commands for
-managing the user's persistent configuration file.
+managing the user's persistent configuration file, and a ``virustotal``
+sub-group for querying the VirusTotal API.
 """
 
 from typing import Optional
@@ -10,6 +11,7 @@ from typing import Optional
 import click
 
 from . import __version__, configs
+from .virustotal import cli as virustotal_group
 
 
 # @common_options(
@@ -35,8 +37,12 @@ def cli() -> None:
     * ``config get <key>`` - read a configuration key
     * ``config delete <key>`` - remove a configuration key
     * ``config list [key]`` - list all keys (or filter by name)
+    * ``virustotal`` - VirusTotal threat intelligence sub-commands
     """
     pass  # pragma: no cover
+
+
+cli.add_command(virustotal_group)
 
 
 @cli.group(name="config")

--- a/src/valkyrie_tools/virustotal.py
+++ b/src/valkyrie_tools/virustotal.py
@@ -1,0 +1,432 @@
+"""VirusTotal integration for valkyrie-tools.
+
+Provides a thin synchronous wrapper around the VirusTotal REST API v3
+(:class:`VirusTotalClient`) and a :data:`cli` Click group that exposes
+five sub-commands:
+
+* ``virustotal url "<url>"`` - submit a URL for scanning
+* ``virustotal domain "<domain>"`` - retrieve a domain report
+* ``virustotal ip "<ip>"`` - retrieve an IP address report
+* ``virustotal hash "<hash>"`` - retrieve a file report by MD5/SHA-1/SHA-256
+* ``virustotal file <path>`` - upload a local file for scanning
+
+The VirusTotal API key is read from the package-level :data:`configs`
+singleton (``GLOBAL.virustotalApiKey``).  Set it once with::
+
+    valkyrie config set virustotalApiKey <your-key>
+
+.. note::
+
+    This module is a scaffold.  The ``VirusTotalClient`` methods and CLI
+    sub-command bodies are intentionally left unimplemented.  See the open
+    pull request for the full implementation spec and contributor checklist.
+"""
+
+# TODO: implement VirusTotalClient methods and CLI sub-command bodies.
+# See the pull-request description for the full spec, API references, and
+# the compliance checklist that must pass before this PR can be merged.
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, Dict
+
+import click
+
+from . import configs
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+VT_API_BASE_URL = "https://www.virustotal.com/api/v3"
+"""Base URL for the VirusTotal REST API v3."""
+
+VT_API_KEY_CONFIG_KEY = "virustotalApiKey"
+"""Config key used to store the VirusTotal API key via ``valkyrie config``."""
+
+VT_NO_API_KEY_MESSAGE = (
+    "VirusTotal API key is not set. "
+    "Run: valkyrie config set virustotalApiKey <your-key>"
+)
+"""Error message shown when the API key has not been configured."""
+
+
+# ---------------------------------------------------------------------------
+# VirusTotalClient
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class VirusTotalClient:
+    """Thin synchronous wrapper around the VirusTotal REST API v3.
+
+    Construct with a valid API key and call the methods below.  All methods
+    return the parsed JSON response as a plain :class:`dict`.
+
+    Args:
+        api_key: A valid VirusTotal API key.
+        base_url: Base URL of the VirusTotal service.  Defaults to
+            ``"https://www.virustotal.com"``.
+        api_version: API version string.  Defaults to ``"v3"``.
+
+    Example:
+        >>> client = VirusTotalClient(api_key="your-key")  # doctest: +SKIP
+        >>> report = client.get_domain("example.com")  # doctest: +SKIP
+    """
+
+    api_key: str
+    base_url: str = "https://www.virustotal.com"
+    api_version: str = "v3"
+    base_api_url: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Build the full base API URL from ``base_url`` and ``api_version``."""
+        self.base_api_url = f"{self.base_url}/api/{self.api_version}"
+
+    def _build_url(self, path: str) -> str:
+        """Construct an absolute API endpoint URL.
+
+        Args:
+            path: Relative path (e.g. ``"files/abc123"``).  A leading ``/``
+                is stripped automatically.
+
+        Returns:
+            The full endpoint URL as a string.
+        """
+        return f"{self.base_api_url}/{path.lstrip('/')}"
+
+    def scan_url(self, url: str) -> Dict[str, Any]:
+        """Submit a URL for scanning.
+
+        Sends a POST request to the ``/urls`` endpoint.  The API returns an
+        analysis object; poll ``/analyses/{id}`` for the finished report.
+
+        See: https://docs.virustotal.com/reference/scan-url
+
+        Args:
+            url: The URL to scan.
+
+        Returns:
+            Parsed JSON response from the VirusTotal API.
+
+        Raises:
+            requests.HTTPError: If the API returns a 4xx or 5xx status.
+            NotImplementedError: Until this method is implemented.
+        """
+        # TODO: POST to /urls with {"url": url} in the request body.
+        # Use requests.post(self._build_url("urls"), ...) with
+        # headers={"x-apikey": self.api_key}.
+        # Raise response.raise_for_status() before returning response.json().
+        raise NotImplementedError
+
+    def get_domain(self, domain: str) -> Dict[str, Any]:
+        """Retrieve a domain report.
+
+        Sends a GET request to ``/domains/{domain}``.
+
+        See: https://docs.virustotal.com/reference/domain-info
+
+        Args:
+            domain: The domain name to look up (e.g. ``"example.com"``).
+
+        Returns:
+            Parsed JSON response from the VirusTotal API.
+
+        Raises:
+            requests.HTTPError: If the API returns a 4xx or 5xx status.
+            NotImplementedError: Until this method is implemented.
+        """
+        # TODO: GET self._build_url(f"domains/{domain}") with
+        # headers={"x-apikey": self.api_key}.
+        # Raise response.raise_for_status() before returning response.json().
+        raise NotImplementedError
+
+    def get_ip(self, ip: str) -> Dict[str, Any]:
+        """Retrieve an IP address report.
+
+        Sends a GET request to ``/ip_addresses/{ip}``.
+
+        See: https://docs.virustotal.com/reference/ip-info
+
+        Args:
+            ip: The IPv4 or IPv6 address to look up.
+
+        Returns:
+            Parsed JSON response from the VirusTotal API.
+
+        Raises:
+            requests.HTTPError: If the API returns a 4xx or 5xx status.
+            NotImplementedError: Until this method is implemented.
+        """
+        # TODO: GET self._build_url(f"ip_addresses/{ip}") with
+        # headers={"x-apikey": self.api_key}.
+        # Raise response.raise_for_status() before returning response.json().
+        raise NotImplementedError
+
+    def get_file(self, hash_value: str) -> Dict[str, Any]:
+        """Retrieve a file report by hash.
+
+        Sends a GET request to ``/files/{hash}`` where ``{hash}`` is an
+        MD5, SHA-1, or SHA-256 digest.
+
+        See: https://docs.virustotal.com/reference/file-info
+
+        Args:
+            hash_value: MD5, SHA-1, or SHA-256 hash of the file.
+
+        Returns:
+            Parsed JSON response from the VirusTotal API.
+
+        Raises:
+            requests.HTTPError: If the API returns a 4xx or 5xx status.
+            NotImplementedError: Until this method is implemented.
+        """
+        # TODO: GET self._build_url(f"files/{hash_value}") with
+        # headers={"x-apikey": self.api_key}.
+        # Raise response.raise_for_status() before returning response.json().
+        raise NotImplementedError
+
+    def scan_file(self, path: str) -> Dict[str, Any]:
+        """Upload a local file for scanning.
+
+        Sends a multipart POST request to ``/files``.  For files larger than
+        32 MB use the ``/files/upload_url`` endpoint to get a one-time upload
+        URL first (out of scope for the initial implementation).
+
+        See: https://docs.virustotal.com/reference/files-scan
+
+        Args:
+            path: Absolute or relative path to the file to upload.
+
+        Returns:
+            Parsed JSON response from the VirusTotal API.
+
+        Raises:
+            FileNotFoundError: If ``path`` does not exist.
+            requests.HTTPError: If the API returns a 4xx or 5xx status.
+            NotImplementedError: Until this method is implemented.
+        """
+        # TODO: Open the file in binary mode and POST it to /files as a
+        # multipart upload:
+        #   with open(path, "rb") as f:
+        #       requests.post(
+        #           self._build_url("files"),
+        #           headers={"x-apikey": self.api_key},
+        #           files={"file": f},
+        #       )
+        # Raise response.raise_for_status() before returning response.json().
+        raise NotImplementedError
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+@click.group(
+    name="virustotal",
+    help="Query the VirusTotal API for threat intelligence.",
+    context_settings={"help_option_names": ["-h", "--help"]},
+)
+def cli() -> None:
+    """VirusTotal threat intelligence sub-commands.
+
+    Requires a VirusTotal API key stored in the package configuration::
+
+        valkyrie config set virustotalApiKey <your-key>
+
+    Sub-commands:
+
+    * ``url "<url>"`` - submit a URL for scanning
+    * ``domain "<domain>"`` - retrieve a domain report
+    * ``ip "<ip>"`` - retrieve an IP address report
+    * ``hash "<hash>"`` - retrieve a file report by hash
+    * ``file <path>`` - upload a local file for scanning
+    """
+    pass  # pragma: no cover
+
+
+def _get_api_key() -> str:
+    """Read the VirusTotal API key from package configuration.
+
+    Returns:
+        The configured API key string.
+
+    Raises:
+        SystemExit: If the key is empty or not set, prints
+            :data:`VT_NO_API_KEY_MESSAGE` and exits with code 1.
+    """
+    # TODO: Replace the stub below with the real implementation:
+    #   key = configs.get("GLOBAL", VT_API_KEY_CONFIG_KEY, fallback="")
+    #   if not key:
+    #       click.echo(VT_NO_API_KEY_MESSAGE, err=True)
+    #       raise SystemExit(1)
+    #   return key
+    raise NotImplementedError
+
+
+def _print_result(result: Dict[str, Any], output_json: bool = False) -> None:
+    """Print an API result to stdout.
+
+    When ``output_json`` is ``True`` the full response is printed as
+    pretty-printed JSON.  Otherwise a human-readable key/value summary of
+    the most relevant fields is printed.
+
+    Args:
+        result: Parsed JSON response dict from :class:`VirusTotalClient`.
+        output_json: If ``True``, emit the full JSON payload.
+    """
+    # TODO: implement the summary view.
+    # The VT API wraps every response in a "data" key.  A useful starting
+    # point for the summary is result.get("data", {}).get("attributes", {}).
+    # For scans (url/file), the relevant field is "last_analysis_stats".
+    # For reports (domain/ip/hash), display "last_analysis_stats" and
+    # "reputation" at minimum.
+    # When output_json is True, just do:
+    #   click.echo(json.dumps(result, indent=2))
+    raise NotImplementedError
+
+
+@cli.command(name="url")
+@click.argument("url", metavar="<url>")
+@click.option(
+    "-j",
+    "--json",
+    "output_json",
+    is_flag=True,
+    default=False,
+    help="Print the full JSON response.",
+)
+def scan_url_cmd(url: str, output_json: bool) -> None:
+    """Submit a URL for scanning.
+
+    Sends the URL to VirusTotal for analysis and prints the result.
+
+    Args:
+        url: The URL to scan.
+        output_json: If set, print the raw JSON response.
+    """
+    # TODO:
+    #   api_key = _get_api_key()
+    #   client = VirusTotalClient(api_key=api_key)
+    #   result = client.scan_url(url)
+    #   _print_result(result, output_json=output_json)
+    raise NotImplementedError  # pragma: no cover
+
+
+@cli.command(name="domain")
+@click.argument("domain", metavar="<domain>")
+@click.option(
+    "-j",
+    "--json",
+    "output_json",
+    is_flag=True,
+    default=False,
+    help="Print the full JSON response.",
+)
+def get_domain_cmd(domain: str, output_json: bool) -> None:
+    """Retrieve a domain report from VirusTotal.
+
+    Args:
+        domain: The domain name to look up.
+        output_json: If set, print the raw JSON response.
+    """
+    # TODO:
+    #   api_key = _get_api_key()
+    #   client = VirusTotalClient(api_key=api_key)
+    #   result = client.get_domain(domain)
+    #   _print_result(result, output_json=output_json)
+    raise NotImplementedError  # pragma: no cover
+
+
+@cli.command(name="ip")
+@click.argument("ip", metavar="<ip>")
+@click.option(
+    "-j",
+    "--json",
+    "output_json",
+    is_flag=True,
+    default=False,
+    help="Print the full JSON response.",
+)
+def get_ip_cmd(ip: str, output_json: bool) -> None:
+    """Retrieve an IP address report from VirusTotal.
+
+    Args:
+        ip: The IPv4 or IPv6 address to look up.
+        output_json: If set, print the raw JSON response.
+    """
+    # TODO:
+    #   api_key = _get_api_key()
+    #   client = VirusTotalClient(api_key=api_key)
+    #   result = client.get_ip(ip)
+    #   _print_result(result, output_json=output_json)
+    raise NotImplementedError  # pragma: no cover
+
+
+@cli.command(name="hash")
+@click.argument("hash_value", metavar="<hash>")
+@click.option(
+    "-j",
+    "--json",
+    "output_json",
+    is_flag=True,
+    default=False,
+    help="Print the full JSON response.",
+)
+def get_hash_cmd(hash_value: str, output_json: bool) -> None:
+    """Retrieve a file report by MD5, SHA-1, or SHA-256 hash.
+
+    Args:
+        hash_value: MD5, SHA-1, or SHA-256 digest of the file.
+        output_json: If set, print the raw JSON response.
+    """
+    # TODO:
+    #   api_key = _get_api_key()
+    #   client = VirusTotalClient(api_key=api_key)
+    #   result = client.get_file(hash_value)
+    #   _print_result(result, output_json=output_json)
+    raise NotImplementedError  # pragma: no cover
+
+
+@cli.command(name="file")
+@click.argument(
+    "path",
+    metavar="<path>",
+    type=click.Path(exists=True, dir_okay=False, readable=True),
+)
+@click.option(
+    "-j",
+    "--json",
+    "output_json",
+    is_flag=True,
+    default=False,
+    help="Print the full JSON response.",
+)
+def scan_file_cmd(path: str, output_json: bool) -> None:
+    """Upload a local file to VirusTotal for scanning.
+
+    Args:
+        path: Path to the file to upload.
+        output_json: If set, print the raw JSON response.
+    """
+    # TODO:
+    #   api_key = _get_api_key()
+    #   client = VirusTotalClient(api_key=api_key)
+    #   result = client.scan_file(path)
+    #   _print_result(result, output_json=output_json)
+    raise NotImplementedError  # pragma: no cover
+
+
+# Keep json available for _print_result even though it is not used yet.
+__all__ = [
+    "VirusTotalClient",
+    "VT_API_BASE_URL",
+    "VT_API_KEY_CONFIG_KEY",
+    "VT_NO_API_KEY_MESSAGE",
+    "cli",
+]
+
+# Suppress "imported but unused" until _print_result uses it.
+_ = json

--- a/tests/test_virustotal.py
+++ b/tests/test_virustotal.py
@@ -1,0 +1,217 @@
+"""Test suite for the virustotal command group.
+
+This module is a scaffold.  Each test method below documents what it must
+verify once :mod:`valkyrie_tools.virustotal` is fully implemented.  All
+tests currently call ``self.skipTest`` so the suite does not fail while the
+feature is being built.
+
+When implementing, replace every ``self.skipTest(...)`` body with real
+assertions.  The suite must achieve **100% branch coverage** before the PR
+can be merged - see ``DEVELOPMENT.md`` for details.
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from valkyrie_tools.virustotal import (
+    VT_NO_API_KEY_MESSAGE,
+    cli,
+)
+
+from .test_base_command import BaseCommandTest
+
+
+class TestVirusTotalCLI(BaseCommandTest, unittest.TestCase):
+    """Tests for the ``virustotal`` Click group and its sub-commands.
+
+    Inherits :class:`~tests.test_base_command.BaseCommandTest` which
+    automatically covers ``--help`` and basic invocation hygiene for the
+    top-level group.
+    """
+
+    command = cli
+
+    def setUp(self) -> None:
+        """Set up test fixtures."""
+        super().setUp()
+
+    def tearDown(self) -> None:
+        """Tear down test fixtures."""
+        super().tearDown()
+
+    # ------------------------------------------------------------------
+    # virustotal url
+    # ------------------------------------------------------------------
+
+    def test_url_no_api_key(self) -> None:
+        """``virustotal url`` exits with an error when no API key is set.
+
+        Mock ``configs.get`` to return an empty string and assert that:
+
+        * the exit code is non-zero, and
+        * :data:`~valkyrie_tools.virustotal.VT_NO_API_KEY_MESSAGE` appears
+          in the output.
+        """
+        self.skipTest("not implemented")
+
+    def test_url_scan_success(self) -> None:
+        """``virustotal url`` calls ``VirusTotalClient.scan_url`` and prints a summary.
+
+        Mock ``configs.get`` to return a fake API key and patch
+        ``VirusTotalClient.scan_url`` to return a representative fixture
+        dict.  Assert that:
+
+        * the exit code is 0, and
+        * key summary fields appear in the output.
+        """
+        self.skipTest("not implemented")
+
+    def test_url_scan_json_flag(self) -> None:
+        """``virustotal url --json`` prints the full JSON payload.
+
+        Same setup as :meth:`test_url_scan_success` but invoke with
+        ``["url", "--json", "<url>"]`` and assert the output is valid JSON
+        matching the fixture dict.
+        """
+        self.skipTest("not implemented")
+
+    def test_url_scan_http_error(self) -> None:
+        """``virustotal url`` handles ``requests.HTTPError`` gracefully.
+
+        Patch ``VirusTotalClient.scan_url`` to raise
+        ``requests.HTTPError`` and assert the command exits with a non-zero
+        code and an informative message.
+        """
+        self.skipTest("not implemented")
+
+    # ------------------------------------------------------------------
+    # virustotal domain
+    # ------------------------------------------------------------------
+
+    def test_domain_no_api_key(self) -> None:
+        """``virustotal domain`` exits with an error when no API key is set."""
+        self.skipTest("not implemented")
+
+    def test_domain_report_success(self) -> None:
+        """``virustotal domain`` calls ``VirusTotalClient.get_domain`` and prints a summary.
+
+        Mock ``configs.get`` to return a fake key and patch
+        ``VirusTotalClient.get_domain`` to return a fixture dict.  Assert
+        exit code 0 and that summary fields appear in output.
+        """
+        self.skipTest("not implemented")
+
+    def test_domain_report_json_flag(self) -> None:
+        """``virustotal domain --json`` prints the full JSON payload."""
+        self.skipTest("not implemented")
+
+    def test_domain_report_http_error(self) -> None:
+        """``virustotal domain`` handles ``requests.HTTPError`` gracefully."""
+        self.skipTest("not implemented")
+
+    # ------------------------------------------------------------------
+    # virustotal ip
+    # ------------------------------------------------------------------
+
+    def test_ip_no_api_key(self) -> None:
+        """``virustotal ip`` exits with an error when no API key is set."""
+        self.skipTest("not implemented")
+
+    def test_ip_report_success(self) -> None:
+        """``virustotal ip`` calls ``VirusTotalClient.get_ip`` and prints a summary.
+
+        Mock ``configs.get`` to return a fake key and patch
+        ``VirusTotalClient.get_ip`` to return a fixture dict.  Assert
+        exit code 0 and that summary fields appear in output.
+        """
+        self.skipTest("not implemented")
+
+    def test_ip_report_json_flag(self) -> None:
+        """``virustotal ip --json`` prints the full JSON payload."""
+        self.skipTest("not implemented")
+
+    def test_ip_report_http_error(self) -> None:
+        """``virustotal ip`` handles ``requests.HTTPError`` gracefully."""
+        self.skipTest("not implemented")
+
+    # ------------------------------------------------------------------
+    # virustotal hash
+    # ------------------------------------------------------------------
+
+    def test_hash_no_api_key(self) -> None:
+        """``virustotal hash`` exits with an error when no API key is set."""
+        self.skipTest("not implemented")
+
+    def test_hash_report_success(self) -> None:
+        """``virustotal hash`` calls ``VirusTotalClient.get_file`` and prints a summary.
+
+        Mock ``configs.get`` to return a fake key and patch
+        ``VirusTotalClient.get_file`` to return a fixture dict.  Assert
+        exit code 0 and that summary fields appear in output.
+        """
+        self.skipTest("not implemented")
+
+    def test_hash_report_json_flag(self) -> None:
+        """``virustotal hash --json`` prints the full JSON payload."""
+        self.skipTest("not implemented")
+
+    def test_hash_report_http_error(self) -> None:
+        """``virustotal hash`` handles ``requests.HTTPError`` gracefully."""
+        self.skipTest("not implemented")
+
+    # ------------------------------------------------------------------
+    # virustotal file
+    # ------------------------------------------------------------------
+
+    def test_file_no_api_key(self) -> None:
+        """``virustotal file`` exits with an error when no API key is set."""
+        self.skipTest("not implemented")
+
+    def test_file_scan_success(self) -> None:
+        """``virustotal file`` calls ``VirusTotalClient.scan_file`` and prints a summary.
+
+        Use ``runner.isolated_filesystem()`` to create a temporary file,
+        mock ``configs.get`` to return a fake key, and patch
+        ``VirusTotalClient.scan_file`` to return a fixture dict.  Assert
+        exit code 0 and that summary fields appear in output.
+        """
+        self.skipTest("not implemented")
+
+    def test_file_scan_json_flag(self) -> None:
+        """``virustotal file --json`` prints the full JSON payload."""
+        self.skipTest("not implemented")
+
+    def test_file_scan_http_error(self) -> None:
+        """``virustotal file`` handles ``requests.HTTPError`` gracefully."""
+        self.skipTest("not implemented")
+
+    def test_file_path_not_found(self) -> None:
+        """``virustotal file`` exits with an error for a non-existent path.
+
+        Invoke with a path that does not exist and assert that Click's
+        built-in path validation rejects it with a non-zero exit code.
+        """
+        self.skipTest("not implemented")
+
+    # ------------------------------------------------------------------
+    # VirusTotalClient unit tests
+    # ------------------------------------------------------------------
+
+    def test_client_build_url(self) -> None:
+        """``VirusTotalClient._build_url`` returns the correct absolute URL.
+
+        Construct a client with a known ``api_key`` and assert that
+        ``_build_url("files/abc123")`` returns
+        ``"https://www.virustotal.com/api/v3/files/abc123"``.
+        Also test that a leading ``/`` in the path is stripped.
+        """
+        self.skipTest("not implemented")
+
+    def test_client_post_init(self) -> None:
+        """``VirusTotalClient.__post_init__`` sets ``base_api_url`` correctly."""
+        self.skipTest("not implemented")
+
+
+# Keep the import visible so flake8 does not flag it as unused before the
+# tests are implemented.
+_referenced = (VT_NO_API_KEY_MESSAGE, MagicMock, patch)


### PR DESCRIPTION
## Overview

This PR adds the **scaffold** for the `virustotal` feature.  The structure,
interfaces, constants, CLI commands, and test stubs are all defined - but
the implementation bodies are intentionally left as `TODO` comments and
`raise NotImplementedError` for the contributor to fill in.

---

## What to build

### Commands

| Command | What it does | VT API reference |
|---|---|---|
| `virustotal url "<url>"` | Submit a URL for scanning | [POST /urls](https://docs.virustotal.com/reference/scan-url) |
| `virustotal domain "<domain>"` | Retrieve a domain report | [GET /domains/{domain}](https://docs.virustotal.com/reference/domain-info) |
| `virustotal ip "<ip>"` | Retrieve an IP address report | [GET /ip_addresses/{ip}](https://docs.virustotal.com/reference/ip-info) |
| `virustotal hash "<hash>"` | Retrieve a file report by MD5/SHA-1/SHA-256 | [GET /files/{hash}](https://docs.virustotal.com/reference/file-info) |
| `virustotal file <path>` | Upload a local file for scanning | [POST /files](https://docs.virustotal.com/reference/files-scan) |

Each command accepts a `-j / --json` flag.  Without it, print a concise
human-readable summary of the most relevant response fields (e.g.
`last_analysis_stats`, `reputation`).  With it, print the full JSON
payload via `json.dumps(result, indent=2)` for piping.

The API key is stored in the package config and read at runtime:

```
valkyrie config set virustotalApiKey <your-key>
```

If the key is not set, the command must exit with a non-zero code and print
`VT_NO_API_KEY_MESSAGE` (already defined in `virustotal.py`).

---

## Third-party client evaluation

Before writing anything, check whether a reputable VirusTotal Python
client exists that is compatible with `>=3.8,<4.0` and matches this
project's synchronous `requests`-based HTTP pattern.

**The official client [`vt-py`](https://pypi.org/project/vt-py/) must not
be used.** It requires `aiohttp` and `aiofiles` (async-only design) which
is incompatible with every other HTTP call in this project.  If you find
another library that fits, document your reasoning in this PR.

If no suitable third-party library exists (the expected outcome), implement
the following internal wrapper in `src/valkyrie_tools/virustotal.py`.  The
skeleton is already in place - fill in each method:

```python
@dataclass
class VirusTotalClient:
    api_key: str
    base_url: str = "https://www.virustotal.com"
    api_version: str = "v3"
    base_api_url: str = field(init=False)

    def __post_init__(self) -> None:
        self.base_api_url = f"{self.base_url}/api/{self.api_version}"

    def _build_url(self, path: str) -> str:
        return f"{self.base_api_url}/{path.lstrip('/')}"

    # Methods to implement (names flexible):
    # scan_url(url: str) -> Dict[str, Any]
    # get_domain(domain: str) -> Dict[str, Any]
    # get_ip(ip: str) -> Dict[str, Any]
    # get_file(hash_value: str) -> Dict[str, Any]
    # scan_file(path: str) -> Dict[str, Any]
```

Each method should use `requests` (already a project dependency) with
`headers={"x-apikey": self.api_key}` and call
`response.raise_for_status()` before returning `response.json()`.

---

## Implementation checklist

Work through these in order.  Every item must be complete before requesting
a review.

- [ ] Evaluate third-party VT libraries; document decision in PR
- [ ] Implement `VirusTotalClient.__post_init__` and `_build_url` (already stubbed, verify they work)
- [ ] Implement `VirusTotalClient.scan_url`
- [ ] Implement `VirusTotalClient.get_domain`
- [ ] Implement `VirusTotalClient.get_ip`
- [ ] Implement `VirusTotalClient.get_file`
- [ ] Implement `VirusTotalClient.scan_file`
- [ ] Implement `_get_api_key` helper in `virustotal.py`
- [ ] Implement `_print_result` helper (summary view + `--json` path)
- [ ] Implement `scan_url_cmd` CLI sub-command body
- [ ] Implement `get_domain_cmd` CLI sub-command body
- [ ] Implement `get_ip_cmd` CLI sub-command body
- [ ] Implement `get_hash_cmd` CLI sub-command body
- [ ] Implement `scan_file_cmd` CLI sub-command body
- [ ] Replace every `self.skipTest(...)` in `tests/test_virustotal.py` with real assertions
- [ ] All quality gates pass (see below)

---

## Compliance requirements

This project has strict quality gates that **CI will reject** if not met.
Read [`DEVELOPMENT.md`](https://github.com/xransum/valkyrie-tools/blob/main/DEVELOPMENT.md)
before writing any code.  The key requirements are summarised below.

### Formatting and linting

black (80-char line length), isort, flake8, and darglint all run
automatically.  Run before every commit:

```bash
poetry run nox -s pre-commit
```

Or manually:

```bash
poetry run black src tests
poetry run isort src tests
poetry run flake8 src tests
```

Key rules:
- Maximum line length: **80 characters**
- Import order: black-compatible (isort `profile = black`)
- Cyclomatic complexity: max **10**
- No unused imports, no bare `except`, no `print` (use `click.echo`)

See [DEVELOPMENT.md - Code Style](https://github.com/xransum/valkyrie-tools/blob/main/DEVELOPMENT.md#code-style)
and [DEVELOPMENT.md - Linting](https://github.com/xransum/valkyrie-tools/blob/main/DEVELOPMENT.md#linting-flake8).

### Docstrings

Every public function, class, and module **must** have a Google-style
docstring.  darglint enforces that `Args:`, `Returns:`, and `Raises:`
sections are present whenever the function has arguments, a return value,
or raises exceptions.

Example of a compliant docstring:

```python
def get_domain(self, domain: str) -> Dict[str, Any]:
    """Retrieve a domain report from VirusTotal.

    Args:
        domain: The domain name to look up (e.g. ``"example.com"``).

    Returns:
        Parsed JSON response from the VirusTotal API.

    Raises:
        requests.HTTPError: If the API returns a 4xx or 5xx status.
    """
```

See [DEVELOPMENT.md - Docstring Standards](https://github.com/xransum/valkyrie-tools/blob/main/DEVELOPMENT.md#docstring-standards).

### Type annotations

mypy runs in **strict mode**.  Every function argument and return type must
be fully annotated.  `requests` stubs (`types-requests`) are already a
project dependency.  Do not use `# type: ignore` without a comment
explaining why.

Run manually:

```bash
poetry run mypy src tests docs/conf.py
```

See [DEVELOPMENT.md - Type Annotations](https://github.com/xransum/valkyrie-tools/blob/main/DEVELOPMENT.md#type-annotations).

### Test coverage

Coverage must be **100%**.  Every branch of every new function must be
exercised.  Never make real network calls in tests - patch
`VirusTotalClient` methods and `requests` calls with `unittest.mock.patch`.

After writing tests:

```bash
poetry run coverage run -m pytest
poetry run coverage report
```

Any line shown as missing in the report must be covered before the PR
can merge.

See [DEVELOPMENT.md - Tests](https://github.com/xransum/valkyrie-tools/blob/main/DEVELOPMENT.md#tests).

### Auto-generated documentation

`docs/reference.rst` already has the `virustotal` CLI and API entries
added in this scaffold.  After implementing the module, verify the Sphinx
build produces **zero warnings**:

```bash
poetry run nox -s docs-build
```

If you add or rename any public function or class, update the docstring
and confirm the build still passes.

See [DEVELOPMENT.md - Session reference (docs-build)](https://github.com/xransum/valkyrie-tools/blob/main/DEVELOPMENT.md#session-reference).

### Full quality gate

Run the complete suite before pushing:

```bash
poetry run nox
```

This runs `pre-commit`, `safety`, `tests`, `xdoctest`, and `docs-build` in
sequence.  All sessions must be green.

### Version

The version has already been bumped from `1.3.2` to `1.4.0` in this
scaffold commit (minor bump for a new backward-compatible feature).  Do
**not** bump it again unless you introduce a breaking change.

---

## Getting started

```bash
# 1. Fork or clone the repo
gh repo fork xransum/valkyrie-tools --clone

# 2. Install dependencies
poetry install

# 3. Check out this branch
git checkout feature/virustotal

# 4. Install pre-commit hooks (run once)
poetry run pre-commit install

# 5. Iterate - run the relevant session after each change
poetry run nox -s tests       # after logic changes
poetry run nox -s pre-commit  # before committing
poetry run mypy src tests docs/conf.py  # after type annotation changes

# 6. Full gate before pushing
poetry run nox
```